### PR TITLE
Show progress of individual steps where available

### DIFF
--- a/pulpstatus/fakepulp.py
+++ b/pulpstatus/fakepulp.py
@@ -127,8 +127,17 @@ def random_progress():
         if i == active:
             state = 'IN_PROGRESS'
         elif i < active:
-            state = 'FINISHED'
-        steps.append({'step_type': step_types[i],
-                      'state': state})
+            state = "FINISHED"
+
+        step = {"step_type": step_types[i], "state": state}
+
+        if random.random() < 0.5:
+            step["items_total"] = 540034
+            step["num_processed"] = 23000
+        elif random.random() < 0.5:
+            step["items_total"] = 10000
+            step["num_processed"] = 9000
+
+        steps.append(step)
 
     return {'some_task': steps}

--- a/pulpstatus/js-src/task-row.spec.ts
+++ b/pulpstatus/js-src/task-row.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 
 import TaskRow from "./task-row";
+import { stepLabel } from "./task-row";
 
 const TEST_ORDER = ['id', 'started', 'type', 'tags', 'worker', 'progress'];
 
@@ -18,4 +19,20 @@ describe('TaskRow', () => {
         const rendered = elem.render();
         expect(!!rendered).to.be.true;
     });
+});
+
+
+describe('stepLabel', () => {
+    it('returns step % when available', () => {
+        const step = {
+            "items_total": 1000,
+            "num_processed": 37,
+            "step_type": "Do the thing",
+            "state": "IN_PROGRESS",
+        };
+
+        const text = stepLabel(step);
+        expect(text).to.be.equal("Do the thing (4%)");
+    });
+
 });

--- a/pulpstatus/js-src/task-row.tsx
+++ b/pulpstatus/js-src/task-row.tsx
@@ -12,7 +12,23 @@ interface TaskRowProps {
 interface Step {
     state: string;
     step_type: string;
+    items_total?: number;
+    num_processed?: number;
 };
+
+export function stepLabel(step: Step): string {
+    let label = step.step_type;
+
+    // If a step has meaningful item counts, we can use that to show
+    // percentage of completion for that step.
+    // Note: most steps don't have a meaningful count.
+    if (step.state == "IN_PROGRESS" && step.items_total && step.items_total > 1 && step.num_processed) {
+        const pct = Math.round(step.num_processed / step.items_total * 100);
+        label = `${label} (${pct}%)`;
+    }
+
+    return label;
+}
 
 type RenderFunction = () => JSX.Element;
 
@@ -105,7 +121,7 @@ export default class extends React.Component<TaskRowProps> {
                 return <ul>
                     {steps.map((step, index) =>
                         <li key={index} className={'step step-' + step.state}>
-                            {step.step_type}
+                            {stepLabel(step)}
                         </li>
                     )}
                 </ul>;


### PR DESCRIPTION
Some steps expose progress in items_total & num_processed.
Where available, we can use these to show a completion percentage.